### PR TITLE
Try to fix release with older software versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: scala
 scala:
-  - 2.13.8
-jdk: openjdk11
+  - 2.13.4
+jdk: openjdk8
 
 before_install:
   - git fetch --tags


### PR DESCRIPTION
Our first attempt at releasing to Maven Central [failed](https://app.travis-ci.com/github/CitrineInformatics/sprandom/jobs/583086322). The error message said it was unable to download Scala 2.13.8, so I'm rolling back the Scala and openjdk versions to ones that we're successfully using for other projects. This is to track down the cause. Ideally we'd prefer to use the more current versions of Scala and openjdk.