### PR TITLE
Fix non-determinism caused by lazily evaluated base rngs

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,8 @@ object Dependencies {
   )
 
   lazy val testDependencies = Seq(
-    "org.scalatest" %% "scalatest" % "3.2.12",
-    "org.scalanlp" %% "breeze" % "2.0"
+    "org.scalatest"           %% "scalatest"                  % "3.2.12",
+    "org.scalanlp"            %% "breeze"                     % "2.0",
+    "org.scala-lang.modules"  %% "scala-parallel-collections" % "1.0.0"
   )
 }

--- a/src/main/scala/io/citrine/random/Random.scala
+++ b/src/main/scala/io/citrine/random/Random.scala
@@ -17,7 +17,12 @@ class Random private (seed: Random.RandomSeed) extends Serializable {
     *
     * @return a new instance of Random whose stream of random numbers are independent of the present stream.
     */
-  def split(): Random = Random(this)
+  def split(): Random = {
+    val split = Random(this)
+    // Underlying split occurs lazily and must be triggered, otherwise non-determinstic behavior can result.
+    split.baseRng
+    split
+  }
 
   /**
     * Generate a uniformly random Long in a given interval.

--- a/src/test/scala/io/citrine/random/RandomTest.scala
+++ b/src/test/scala/io/citrine/random/RandomTest.scala
@@ -4,6 +4,7 @@ import java.util.SplittableRandom
 import java.io._
 import breeze.stats.distributions.{ChiSquared, RandBasis}
 import org.scalatest.funsuite.AnyFunSuite
+import scala.collection.parallel.CollectionConverters.IterableIsParallelizable
 
 class RandomTest extends AnyFunSuite {
 
@@ -198,5 +199,16 @@ class RandomTest extends AnyFunSuite {
       assert(chiSq > chiSqCriticalValueLower)
       assert(chiSq < chiSqCriticalValueUpper)
     }
+  }
+
+  test("Check deterministic behavior of zip when applied to a parallel operation") {
+    val seed = 718352L
+    val iterator = Range(0, 10).toVector
+    val allResults = (0 until 5).map { _ =>
+      val rng = Random(seed)
+      rng.zip(iterator).par.map { case (thisRng, _) => thisRng.nextLong() }.toVector
+    }
+    val firstResult = allResults.head
+    allResults.tail.foreach(thisResult => assert(thisResult == firstResult))
   }
 }


### PR DESCRIPTION
Splitting produces a new instance of `Random` but its underlying `baseRng` (and hence the underlying split) is triggered lazily. Therefore if multiple splits occur, as they do with `zip`, the result can be non-deterministic. This is fixed by triggering evaluation of the `baseRng` during a split.