### PR TITLE
Add support for Option[Long]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: scala
 scala:
-  - 2.13.4
+  - 2.13.11
 jdk: openjdk11
 
 before_install:

--- a/build.sbt
+++ b/build.sbt
@@ -1,15 +1,17 @@
 import Dependencies._
 
-ThisBuild / scalaVersion := "2.13.4"
+ThisBuild / scalaVersion := "2.13.11"
 ThisBuild / organization := "io.citrine"
 ThisBuild / organizationName := "Citrine Informatics"
 ThisBuild / homepage := Some(url("https://github.com/CitrineInformatics/sprandom"))
-ThisBuild / developers := List(Developer(
-  id="Citrine",
-  name="Citrine Informatics",
-  email="public-repository@citrine.io",
-  url=url("https://github.com/CitrineInformatics")
-))
+ThisBuild / developers := List(
+  Developer(
+    id = "Citrine",
+    name = "Citrine Informatics",
+    email = "public-repository@citrine.io",
+    url = url("https://github.com/CitrineInformatics")
+  )
+)
 ThisBuild / description := "Splittable, serializable pseudorandom number generation in Scala."
 ThisBuild / licenses += "Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0.txt")
 

--- a/src/main/scala/io/citrine/random/Random.scala
+++ b/src/main/scala/io/citrine/random/Random.scala
@@ -163,6 +163,7 @@ class Random private (seed: Random.RandomSeed) extends Serializable {
 }
 
 object Random {
+
   sealed private trait RandomSeed
   private case class EmptySeed() extends RandomSeed
   private case class LongSeed(value: Long) extends RandomSeed

--- a/src/main/scala/io/citrine/random/Random.scala
+++ b/src/main/scala/io/citrine/random/Random.scala
@@ -5,9 +5,9 @@ import scala.collection.BuildFrom
 import scala.collection.mutable.ArrayBuffer
 
 class Random private (seed: Random.RandomSeed) extends Serializable {
+
   @transient private lazy val baseRng: SplittableRandom = seed match {
     case Random.EmptySeed()     => new SplittableRandom
-    case Random.IntSeed(value)  => new SplittableRandom(value.toLong)
     case Random.LongSeed(value) => new SplittableRandom(value)
     case Random.RngSeed(value)  => value.baseRng.split()
   }
@@ -163,16 +163,25 @@ class Random private (seed: Random.RandomSeed) extends Serializable {
 }
 
 object Random {
-  sealed trait RandomSeed
-  case class EmptySeed() extends RandomSeed
-  case class IntSeed(value: Int) extends RandomSeed
-  case class LongSeed(value: Long) extends RandomSeed
-  case class RngSeed(value: Random) extends RandomSeed
+  sealed private trait RandomSeed
+  private case class EmptySeed() extends RandomSeed
+  private case class LongSeed(value: Long) extends RandomSeed
+  private case class RngSeed(value: Random) extends RandomSeed
 
   def apply(): Random = new Random(EmptySeed())
-  def apply(seed: Int): Random = new Random(IntSeed(seed))
-  def apply(seed: Long): Random = new Random(LongSeed(seed))
+
   def apply(seed: Random): Random = new Random(RngSeed(seed))
+
+  def apply(seed: Int): Random = new Random(LongSeed(seed.toLong))
+
+  def apply(seed: Long): Random = new Random(LongSeed(seed))
+
+  def apply(seed: Option[Long]): Random = {
+    seed match {
+      case Some(x) => new Random(LongSeed(x))
+      case _       => new Random(EmptySeed())
+    }
+  }
 
   /** Construct a default Random object seeded from the global RNG. */
   def default: Random = Random(scala.util.Random.nextLong())

--- a/src/test/scala/io/citrine/random/RandomTest.scala
+++ b/src/test/scala/io/citrine/random/RandomTest.scala
@@ -211,4 +211,21 @@ class RandomTest extends AnyFunSuite {
     val firstResult = allResults.head
     allResults.tail.foreach(thisResult => assert(thisResult == firstResult))
   }
+
+  test("Random can be seeded with optional values") {
+    val seed: Long = 53
+    val optionSeed: Option[Long] = Some(seed)
+    val emptySeed: Option[Long] = None
+
+    val direct = Random(seed)
+    val indirect = Random(optionSeed)
+    val empty = Random(emptySeed)
+
+    val directValue = direct.nextLong()
+    val indirectValue = indirect.nextLong()
+    val emptyValue = empty.nextLong()
+
+    assert(directValue == indirectValue)
+    assert(directValue != emptyValue)
+  }
 }


### PR DESCRIPTION
Most Python RNG's accept an Optional[int] for their constructors. This makes the interface a bit cleaner when we have an optional seed, so we don't have to manually unpack it in the calling code.